### PR TITLE
Kernelsoptimization

### DIFF
--- a/src/KernelComputation.cpp
+++ b/src/KernelComputation.cpp
@@ -287,8 +287,10 @@ double HyperbolicTangentKernel(arma::vec x,arma::vec y,arma::vec parms)
 double SplineKernel(arma::vec x,arma::vec y,arma::vec parms)
 {
   double prod = 1;
+  double minxy;
   for(int i = 0;i < x.size();i++){
-    double res = 1 + (x(i)*y(i)*std::min(x(i),y(i))) - ((x(i) + y(i)) / 2.0) * (std::pow(std::min(x(i),y(i)),2) + (std::pow(std::min(x(i),y(i)),3) / 3.0));
+    minxy = std::min(x(i),y(i));
+    double res = 1 + (x(i) * y(i) * minxy) - ((x(i) + y(i)) / 2.0) * (minxy*minxy + (minxy*minxy*minxy / 3.0));
     prod = prod * res;
   }
   return(prod);


### PR DESCRIPTION
Melhorias nas funções e formatação melhorada para leitura mais clara.

- coisas como std::pow(var,2) foram reduzidas para var*var
- termos que estavam sendo calculados varias vezes, gerando maior custo computacional como min(x(i),y(i)) foram salvos em variaveis como minxy para que sejam reutilizados sem precisar recalcular.